### PR TITLE
- Focus window on loading and on clicking

### DIFF
--- a/src/compat/index.html
+++ b/src/compat/index.html
@@ -43,6 +43,9 @@
         loadingContext.fillText("Powered By LÖVE.", canvas.scrollWidth / 2, canvas.scrollHeight / 4 * 3);
       }
 
+      window.onload = function () { window.focus(); };
+      window.onclick = function () { window.focus(); };
+
       window.addEventListener("keydown", function(e) {
         // space and arrow keys
         if([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {

--- a/src/release/index.html
+++ b/src/release/index.html
@@ -43,6 +43,9 @@
         loadingContext.fillText("Powered By LÖVE.", canvas.scrollWidth / 2, canvas.scrollHeight / 4 * 3);
       }
 
+      window.onload = function () { window.focus(); };
+      window.onclick = function () { window.focus(); };
+
       window.addEventListener("keydown", function(e) {
         // space and arrow keys
         if([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {


### PR DESCRIPTION
When hosting your game on sites like Itch.io, it's not possible to gain focus after losing focus. This means that any key you press will not reach the game. This can be fixed by calling `window.focus` when the window is clicked.