### PR TITLE
Update docs around SharedArrayBuffer support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,12 +58,18 @@ You can also replace `love-js` in the above command with `index.js` (or ` node i
 1. Compatibility version (`-c`) should work with most browsers. The difference is that pthreads aren't used. This results in *dodgy audio*. 
 2. The normal version works in the latest Chrome and should work with the latest Firefox version. 
 
-In Firefox, the normal version can throw `Uncaught ReferenceError: SharedArrayBuffer is not defined`. Fix is discussed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#Security_requirements). TL;DR 
+The normal version can throw `Uncaught ReferenceError: SharedArrayBuffer is not defined`. Fix is discussed [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#Security_requirements). TL;DR 
 Enable the following HTML reponse headers on the website you're hosting your project on:
 ```
 Cross-Origin-Opener-Policy: same-origin
 Cross-Origin-Embedder-Policy: require-corp
 ```
+> If you want to publish your game on one of the game hosting platforms, like [itch.io](https://itch.io/) for example:
+> - if they include these headers, use the standard version
+> - if they don't, use the compatibility mode instead (`-c`)
+> 
+> On itch.io, they are disabled by default, but they provide experimental support for it. Read more about this [here](https://itch.io/t/2025776/experimental-sharedarraybuffer-support).
+
 3. Memory is now dynamically resized even with pthreads thanks to [this](https://github.com/emscripten-core/emscripten/pull/8365). Still needs a large-enough initial memory until I figure out how to properly wait for the memory to be sized-up before initialising all the file-system stuff (pointers [here](https://emscripten.org/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions)).
 4. Shaders work (check out 3D demo), but require stricter type-checking. _The OpenGL ES Shading Language is type safe. There are no implicit conversions between types_ ([source](https://www.khronos.org/registry/OpenGL/specs/es/3.2/GLSL_ES_Specification_3.20.pdf)). So something like
 ```GLSL


### PR DESCRIPTION
`SharedArrayBuffer is not defined` will be thrown on more than just Firefox now (Chrome dropped the support for non cross origin isolated use recently), so I thought we could update the documentation around _when_ to use the compatibility mode.

On another note, itch.io added a way to enable the required headers, as an experimental option, so I've added something about it as well.

There's a great explanation here: https://itch.io/t/2025776/experimental-sharedarraybuffer-support