### PR TITLE
Fix footer capturing mouse events

### DIFF
--- a/sample/theme/love.css
+++ b/sample/theme/love.css
@@ -23,7 +23,7 @@ footer {
     padding-bottom: 10px;
     position:absolute;
     bottom: 0;
-    width: 100%;
+    width: auto;
 }
 
 /* Links */

--- a/src/compat/theme/love.css
+++ b/src/compat/theme/love.css
@@ -23,7 +23,7 @@ footer {
     padding-left: 10px;
     position:absolute;
     bottom: 0;
-    width: 100%;
+    width: auto;
 }
 
 /* Links */

--- a/src/release/theme/love.css
+++ b/src/release/theme/love.css
@@ -23,7 +23,7 @@ footer {
     padding-left: 10px;
     position:absolute;
     bottom: 0;
-    width: 100%;
+    width: auto;
 }
 
 /* Links */


### PR DESCRIPTION
If the browser window is too small, some mouse events will not be registered by the game. This is because footer element takes up more horizontal space that it needs. Changing footer width from "100%" to "auto" will make it occupy only the required amount of space, and not capture mouse events intended for the bottom of game canvas.